### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ This is a service library for the DreamFactory platform containing a SQL databas
 This is an add on to the DreamFactory Core library and requires the [df-core repository] (http://github.com/dreamfactorysoftware/df-core).
 
 This code is governed by a commercial license. To use it, you must follow the [terms of use](http://dreamfactory.com/termsofuse), refer to the LICENSE file.
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,16 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-sqldb": "~1.0"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-sqldb": "~1.4"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Database/Schema/Grammars/InformixGrammar.php
+++ b/src/Database/Schema/Grammars/InformixGrammar.php
@@ -50,23 +50,37 @@ class InformixGrammar extends Grammar
     }
 
     /**
-     * Compile the query to determine the list of tables.
+     * Compile the query to determine if a given table exists.
+     *
+     * @param  string|null  $schema
+     * @param  string       $table
      *
      * @return string
      */
-    public function compileTableExists()
+    public function compileTableExists($schema, $table)
     {
-        return 'select * from information_schema.tables where table_schema = "?" and table_name = "?"';
+        return sprintf(
+            'select * from information_schema.tables where table_schema = %s and table_name = %s',
+            $schema ? $this->quoteString($schema) : "''",
+            $this->quoteString($table)
+        );
     }
 
     /**
      * Compile the query to determine the list of columns.
      *
+     * @param  string|null  $schema
+     * @param  string       $table
+     *
      * @return string
      */
-    public function compileColumnExists()
+    public function compileColumnExists($schema, $table)
     {
-        return 'select column_name from information_schema.columns where table_schema = "?" and table_name = "?"';
+        return sprintf(
+            'select column_name from information_schema.columns where table_schema = %s and table_name = %s',
+            $schema ? $this->quoteString($schema) : "''",
+            $this->quoteString($table)
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Bumps df-informix to Laravel 13.7 / PHP 8.3 / PHPUnit 11.5.3 / orchestra/testbench 11
- Aligns the SQL connector dependency on `dreamfactory/df-sqldb: ~1.4` (the L13 minor)
- Promotes `laravel/helpers ^1.8` to a production require so downstream consumers get `array_get` / `camel_case` / `array_except` polyfills without extra wiring
- Updates `Schema\Grammars\InformixGrammar::compileTableExists()` to the new `(string|null $schema, string $table)` signature introduced on `Illuminate\Database\Schema\Grammars\Grammar` in Laravel 13, and aligns `compileColumnExists()` for consistency

## Wave 2 context
Part of the Laravel 11 -> 13 upgrade campaign. Builds on the matched `shift/laravel-13` branches of df-core, df-system, df-database and df-sqldb (Wave 0/1). Mirrors the constraint pattern landed in df-mysqldb (also a Wave 2 SQL connector).

## Stage 1 (isolated install + smoke)
- `composer validate --strict` -> valid
- `composer install --no-dev` against path-repo siblings (df-core/df-system/df-database/df-sqldb on `shift/laravel-13`) -> installs cleanly under L13.7.0
- `php -l` -> all 9 source files clean
- Autoload smoke: 9 namespaced classes load, 3 helper polyfills present, `Application::VERSION == 13.7.0`

## Stage 2 (host-app integration)
- shift-173254 worktree of `dreamfactory/dreamfactory` with the standard Wave-1 strip-list (`df-mongo-logs`, `df-git`, `df-oauth`, `df-mcp-server`) and `MongoDB\Laravel\MongoDBServiceProvider::class` commented out in `config/app.php`
- Path-repo aliases for `df-core`, `df-system`, `df-database`, `df-sqldb`, `df-informix` (shift/laravel-13)
- `composer install --no-dev` resolves and links df-informix into the host vendor tree
- Same autoload smoke passes inside the host app: 9/9 classes + 3/3 helpers + L13.7.0

## Test plan
- [ ] CI on shift/laravel-13 once the wave merges align (df-core/df-system/df-database/df-sqldb need to ship `^13.7`-resolvable releases first)
- [ ] Live-DB integration smoke against an Informix instance (deferred - same as df-sqldb wave PR)
- [ ] Confirm `Schema::hasTable()` / `Schema::hasColumn()` calls against an Informix connection produce the expected rows (the new `compileTableExists` / `compileColumnExists` signatures are now executed by `Illuminate\Database\Schema\Builder`, replacing the previous unbound-`?` template)